### PR TITLE
Changes to support Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.18.4
-PyYAML==3.12
+PyYAML==3.13

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'requests==2.18.4'
+        'requests==2.18.4',
+        'PyYAML==3.13'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/third_party_license_file_generator/site_packages.py
+++ b/third_party_license_file_generator/site_packages.py
@@ -7,6 +7,7 @@ import signal
 import subprocess
 import sys
 import platform
+from codecs import open
 
 from third_party_license_file_generator.licenses import (build_license_file_for_author,
                                                          get_license_from_github_home_page_scrape,

--- a/third_party_license_file_generator/site_packages.py
+++ b/third_party_license_file_generator/site_packages.py
@@ -23,7 +23,6 @@ def _run_subprocess(command_line):
         p = subprocess.Popen(
             executable=sys.executable,
             args=shlex.split(command_line),
-            cwd=os.getcwd(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
@@ -41,10 +40,7 @@ def _run_subprocess(command_line):
         stdout, stderr = None, None
 
     try:
-        if platform.system() == 'Windows':
-            p.send_signal(signal.CTRL_BREAK_EVENT)
-        else:
-            p.terminate()
+        p.terminate()
     except Exception:
         pass
 

--- a/third_party_license_file_generator/site_packages.py
+++ b/third_party_license_file_generator/site_packages.py
@@ -5,6 +5,8 @@ import os
 import shlex
 import signal
 import subprocess
+import sys
+import platform
 
 from third_party_license_file_generator.licenses import (build_license_file_for_author,
                                                          get_license_from_github_home_page_scrape,
@@ -17,12 +19,21 @@ def _pre_exec():
 
 
 def _run_subprocess(command_line):
-    p = subprocess.Popen(
-        shlex.split(command_line),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        preexec_fn=_pre_exec
-    )
+    if platform.system() == 'Windows':
+        p = subprocess.Popen(
+            executable=sys.executable,
+            args=shlex.split(command_line),
+            cwd=os.getcwd(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+    else:
+        p = subprocess.Popen(
+            args=shlex.split(command_line),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            preexec_fn=_pre_exec
+        )
 
     try:
         stdout, stderr = [x.strip() for x in p.communicate()]
@@ -30,7 +41,10 @@ def _run_subprocess(command_line):
         stdout, stderr = None, None
 
     try:
-        p.terminate()
+        if platform.system() == 'Windows':
+            p.send_signal(signal.CTRL_BREAK_EVENT)
+        else:
+            p.terminate()
     except Exception:
         pass
 
@@ -155,7 +169,7 @@ class SitePackages(object):
 
         try:
             site_packages_path = [
-                x for x in sys_path if '/site-packages' in x
+                x for x in sys_path if 'site-packages' in x
             ][0]
         except Exception:
             return None
@@ -163,7 +177,7 @@ class SitePackages(object):
         return site_packages_path
 
     def _read_metadata(self, metadata_path):
-        with open(metadata_path, 'r') as f:
+        with open(metadata_path, 'r', encoding="utf-8") as f:
             data = f.read().replace('\r\n', '\n')
 
         interesting_data = data.split('\n\n')[0].strip()
@@ -217,7 +231,7 @@ class SitePackages(object):
             metadata = None
             license_file = None
             for sub_thing in os.listdir(path_to_thing):
-                path_to_sub_thing = '{0}/{1}'.format(path_to_thing, sub_thing)
+                path_to_sub_thing = os.path.join(path_to_thing, sub_thing)
                 if not os.path.isfile(path_to_sub_thing):
                     continue
 
@@ -241,7 +255,7 @@ class SitePackages(object):
                 self._module_licenses_by_module_name[module_name] = license_file
 
     def _read_license(self, license_path):
-        with open(license_path, 'r') as f:
+        with open(license_path, 'r', encoding='utf-8', errors='ignore') as f:
             data = f.read()
 
         return data.strip()


### PR DESCRIPTION
1. `subprocess.Popen()` has platform specific arguments. Added a platform check before calling a Windows compatible version of the call.
2. Replaced a manual path join with a `os.path.join` call (and removed unnecessary `/`)
3. Added `encoding='utf-8', errors='ignore'` parameters to the file.open call to resolve issues where some files contained un-parseable characters.

I've done basic testing to confirm that it works correctly on Windows and macOS.