### PR TITLE
Fix commercial exceptions not taken into account

### DIFF
--- a/third_party_license_file_generator/__main__.py
+++ b/third_party_license_file_generator/__main__.py
@@ -216,7 +216,8 @@ if __name__ == '__main__':
                 [x in args.gpl_exception for x in module_names]):
             warning = gpl_warning
             gpl_triggered = True
-        elif not args.permit_commercial and license_name in ['Commercial', 'Unknown (assumed commercial)']:
+        elif not args.permit_commercial and license_name in ['Commercial', 'Unknown (assumed commercial)'] and not all(
+                [x in args.commercial_exception for x in module_names]):
             warning = commercial_warning
             commercial_triggered = True
 


### PR DESCRIPTION
Commercial exceptions were not really taken into account.

Tested manually in a windows python environment where I had 2 commercial packages.
Without the fix, I got an error saying that commercial packages were found.
With the fix, I got no error.