### PR TITLE
Do not skip not required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can specify a number of command line options (check syntax with -h) to do th
 - specific comercially-licensed package exceptions (e.g. if you have a license for a package or if you own a package)
 - a "skip prefix" (e.g. if you want to skip all packages starting with a certain string)
 - disable internet lookups (if you don't want to pull data from PyPI and GitHub)
+- disable skipping of not required packages (packages that are not requirements of other packages are skipped by default during license file generation)
 
 ## Examples
 

--- a/third_party_license_file_generator/__main__.py
+++ b/third_party_license_file_generator/__main__.py
@@ -86,6 +86,15 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    '-d',
+    '--do-not-skip-not-required-packages',
+    action='store_true',
+    required=False,
+    default=False,
+    help='do not skip packages that are not requirements of other packages',
+)
+
+parser.add_argument(
     '-o',
     '--output-file',
     type=str,
@@ -185,6 +194,7 @@ if __name__ == '__main__':
                 skip_prefixes=args.skip_prefix,
                 use_internet=not args.no_internet_lookups,
                 license_overrides=license_overrides,
+                do_not_skip_not_required_packages=args.do_not_skip_not_required_packages,
             )
         ]
 

--- a/third_party_license_file_generator/site_packages.py
+++ b/third_party_license_file_generator/site_packages.py
@@ -90,12 +90,13 @@ class LicenseError(Exception):
 
 class SitePackages(object):
     def __init__(self, requirements_path, python_path=None, skip_prefixes=None,
-                 autorun=True, use_internet=True, license_overrides=None):
+                 autorun=True, use_internet=True, license_overrides=None, do_not_skip_not_required_packages=False):
         self._requirements_path = requirements_path
         self._python_path = python_path if python_path is not None else distutils.spawn.find_executable('python3')
         self._skip_prefixes = skip_prefixes
         self._use_internet = use_internet
         self._license_overrides = license_overrides if license_overrides is not None else {}
+        self._do_not_skip_not_required_packages = do_not_skip_not_required_packages
 
         self._root_module_names = set()
         self._required_module_names = set()
@@ -259,7 +260,7 @@ class SitePackages(object):
 
     def _read_site_packages(self):
         for module_name, metadata in self._module_metadatas_by_module_name.items():
-            if module_name not in self._root_module_names and module_name not in self._required_module_names:
+            if not self._do_not_skip_not_required_packages and module_name not in self._root_module_names and module_name not in self._required_module_names:
                 # print('skipping', module_name, 'as it\'s not in the root modules or any of their requirements')
                 # print('')
                 continue


### PR DESCRIPTION
With the current behaviour when a package is not required by any other package no license is generated for it.
This can be problematic when some of the packages don't specify correctly the list of requirements. 
For this I added an argument that disabled the skipping of not-required packages. This can be used when one is sure that all packages are required.