### PR TITLE
Fix issue where site-packages of python venv is not read correctly

### DIFF
--- a/third_party_license_file_generator/site_packages.py
+++ b/third_party_license_file_generator/site_packages.py
@@ -22,8 +22,7 @@ def _pre_exec():
 def _run_subprocess(command_line):
     if platform.system() == 'Windows':
         p = subprocess.Popen(
-            executable=sys.executable,
-            args=shlex.split(command_line),
+            args=command_line.split(),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)


### PR DESCRIPTION
As described by #4 , when specifying a different python executable, site-packages are not read from the environment of that python executable. (at least on windows).

With the solution proposed in the issue it seems to work fine.