### PR TITLE
Loosen install requirements to avoid dependency conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,8 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'requests==2.25.1',
-        'PyYAML==5.4.1'
+        'requests>=2.25',
+        'PyYAML>=5.4'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Should address https://github.com/ftpsolutions/python-third-party-license-file-generator/issues/12. Happy to change the particular versions if necessary.