### PR TITLE
Update __main__.py

### DIFF
--- a/third_party_license_file_generator/__main__.py
+++ b/third_party_license_file_generator/__main__.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
     license_overrides = {}
     if args.license_override_file is not None:
         with codecs.open(args.license_override_file, "r", "utf-8") as f:
-            license_overrides = yaml.load(f.read())
+            license_overrides = yaml.load(f.read(), Loader=yaml.SafeLoader)
 
         for module_name, license_override in license_overrides.items():
             license_name = license_override.get("license_name")


### PR DESCRIPTION
with the lately accepted pull request that opened the door for more recent pyyaml-versions the loader should be specified when loading a license override file (at least in our pipelines this suddenly lead to fails [and safe loader should be ok since there are just some strings being loaded and no complex data structures])

![image](https://user-images.githubusercontent.com/100191382/155090213-7e0e8124-dd61-40ce-9e79-228fb5896dfd.png)
