### PR TITLE
Fix parsing from METADATA defined with pyproject.toml 

### DIFF
--- a/third_party_license_file_generator/site_packages.py
+++ b/third_party_license_file_generator/site_packages.py
@@ -15,6 +15,11 @@ from third_party_license_file_generator.licenses import (
     parse_license,
 )
 
+# Metadata keys/prefixes that are created when a project is packaged using
+# pyproject.toml instead of setup.py
+_TOML_METADATA_HOMEPAGE_PREFIX = "Project-URL: Homepage, "
+_TOML_METADATA_LICENSE_PREFIX = "Classifier: License :: OSI Approved :: "
+
 
 def _pre_exec():
     signal.signal(signal.SIGINT, signal.SIG_IGN)  # to ignore CTRL+C signal in the new process
@@ -191,6 +196,20 @@ class SitePackages(object):
 
         return site_packages_path
 
+    @staticmethod
+    def _set_metadata_dict_value(metadata_dict, key, value):
+        # In the implementation of the metadata parsing we look for keys that are present in
+        # older style setup.py metadata AND newer style pyproject.toml metadata.
+        # We don't expect to encounter a situation where this presents an issue, but it might.
+        # Add some logging for this case.
+        if metadata_dict.get(key, None) is not None:
+            print("INFO: key {} is already set in metadata. Changing value from {} to {}".format(
+                key,
+                metadata_dict[key],
+                value,
+            ))
+        metadata_dict[key] = value
+
     def _read_metadata(self, metadata_path):
         with open(metadata_path, "r", encoding="utf-8") as f:
             data = f.read().replace("\r\n", "\n")
@@ -221,9 +240,23 @@ class SitePackages(object):
                 metadata["author"] += " <{0}>".format(value)
                 metadata["author"] = metadata["author"].strip()
             elif key == "Home-page":
-                metadata["home_page"] = value
+                # Used for setup.py metadata packages
+                self._set_metadata_dict_value(metadata_dict=metadata, key="home_page", value=value)
             elif key == "License":
-                metadata["license_name"] = value
+                # Used for setup.py metadata packages
+                self._set_metadata_dict_value(metadata_dict=metadata, key="license_name", value=value)
+            elif line.startswith(_TOML_METADATA_HOMEPAGE_PREFIX):
+                # Used for pyproject.toml metadata packages
+                # Line example: Project-URL: Homepage, https://github.com/carltongibson/django-filter/tree/main
+                self._set_metadata_dict_value(metadata_dict=metadata, key="home_page",
+                                              value=line.split(_TOML_METADATA_HOMEPAGE_PREFIX)[-1])
+            elif line.startswith(_TOML_METADATA_LICENSE_PREFIX):
+                # Used for pyproject.toml metadata packages
+                # Line example:
+                # Classifier: License :: OSI Approved :: MIT License
+                self._set_metadata_dict_value(metadata_dict=metadata,
+                                              key="license_name",
+                                              value=line.split(_TOML_METADATA_LICENSE_PREFIX)[-1])
             elif key == "Requires-Dist":
                 if ";" not in value:
                     module_name = value.split("(")[0].split("<")[0].split(">")[0].split("=")[0].strip()

--- a/third_party_license_file_generator/site_packages.py
+++ b/third_party_license_file_generator/site_packages.py
@@ -197,13 +197,14 @@ class SitePackages(object):
         return site_packages_path
 
     @staticmethod
-    def _set_metadata_dict_value(metadata_dict, key, value):
+    def _set_metadata_dict_value(metadata_path, metadata_dict, key, value):
         # In the implementation of the metadata parsing we look for keys that are present in
         # older style setup.py metadata AND newer style pyproject.toml metadata.
         # We don't expect to encounter a situation where this presents an issue, but it might.
         # Add some logging for this case.
         if metadata_dict.get(key, None) is not None:
-            print("INFO: key {} is already set in metadata. Changing value from {} to {}".format(
+            print("INFO: For METADATA {} key {} is already set in parsed metadata. Changing value from {} to {}".format(
+                metadata_path,
                 key,
                 metadata_dict[key],
                 value,
@@ -241,20 +242,29 @@ class SitePackages(object):
                 metadata["author"] = metadata["author"].strip()
             elif key == "Home-page":
                 # Used for setup.py metadata packages
-                self._set_metadata_dict_value(metadata_dict=metadata, key="home_page", value=value)
+                self._set_metadata_dict_value(metadata_path=metadata_path,
+                                              metadata_dict=metadata,
+                                              key="home_page",
+                                              value=value)
             elif key == "License":
                 # Used for setup.py metadata packages
-                self._set_metadata_dict_value(metadata_dict=metadata, key="license_name", value=value)
+                self._set_metadata_dict_value(metadata_path=metadata_path,
+                                              metadata_dict=metadata,
+                                              key="license_name",
+                                              value=value)
             elif line.startswith(_TOML_METADATA_HOMEPAGE_PREFIX):
                 # Used for pyproject.toml metadata packages
                 # Line example: Project-URL: Homepage, https://github.com/carltongibson/django-filter/tree/main
-                self._set_metadata_dict_value(metadata_dict=metadata, key="home_page",
+                self._set_metadata_dict_value(metadata_path=metadata_path,
+                                              metadata_dict=metadata,
+                                              key="home_page",
                                               value=line.split(_TOML_METADATA_HOMEPAGE_PREFIX)[-1])
             elif line.startswith(_TOML_METADATA_LICENSE_PREFIX):
                 # Used for pyproject.toml metadata packages
                 # Line example:
                 # Classifier: License :: OSI Approved :: MIT License
-                self._set_metadata_dict_value(metadata_dict=metadata,
+                self._set_metadata_dict_value(metadata_path=metadata_path,
+                                              metadata_dict=metadata,
                                               key="license_name",
                                               value=line.split(_TOML_METADATA_LICENSE_PREFIX)[-1])
             elif key == "Requires-Dist":


### PR DESCRIPTION
Fixed reading license and homepage from metadata file when package defined using pyproject.toml

Tested by:

Creating a python 3.12 VirtualEnv
Creating a requirements file called test-req.txt with the contents - these are some problematic packages that we ran into:

```

django-filter==23.5
setuptools==71.0.3

```

Run the license generation from the repo root, using the previously made VirtualEnv

```

pip uninstall -y django-filter && pip install --upgrade setuptools==71.0.3 && pip install --no-cache-dir -r test-req.txt && python -m third_party_license_file_generator -r test-req.txt  -p VirtualEnv/bin/python -o TEST_OUT_LICENSES

```

Successful license generation where it was previously failing to identify the license

![image](https://github.com/user-attachments/assets/5eed7296-0959-46b2-8a40-b0322f6fe3b4)



