### PR TITLE
Replace distutils.spawn.find_executable with shutil.which

### DIFF
--- a/third_party_license_file_generator/site_packages.py
+++ b/third_party_license_file_generator/site_packages.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import distutils
+import shutil
 import os
 import shlex
 import signal
@@ -116,7 +116,7 @@ class SitePackages(object):
         do_not_skip_not_required_packages=False,
     ):
         self._requirements_path = requirements_path
-        self._python_path = python_path if python_path is not None else distutils.spawn.find_executable("python3")  # noqa
+        self._python_path = python_path if python_path is not None else shutil.which("python3")  # noqa
         self._skip_prefixes = skip_prefixes
         self._use_internet = use_internet
         self._license_overrides = license_overrides if license_overrides is not None else {}


### PR DESCRIPTION
The `distutils` module is deprecated since Python 3.10 and has been removed in Python 3.12.

---

Hi, we've had to use a fork to bring support for Python 3.12. As far as I can tell `shutil.which` is a drop-in replacement and a bunch of other libraries have made this same update. This change seems to be working fine for us.