### PR TITLE
Handle top_level.txt file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "third-party-license-file-generator"
-version = "2025.10.23"
+version = "2025.12.12"
 description = "The Python third_party_license_file_generator is aimed at distilling down the appropriate license for one or many pip \"requirements\" files into a single file; it supports Python2.7 and Python3."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="2025.10.23",
+    version="2025.12.12",
     description='The Python third_party_license_file_generator is aimed at distilling down the appropriate license for one or many pip "requirements" files into a single file; it supports Python2.7 and Python3.',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
For some packages, the name of the module != the name of the imports exposed. This caused the third-party-license-file-generator to ignore the dependency.

An example of a problematic package is: https://pypi.org/project/mysql-connector-python/

Module name: mysql_connector
Top-level import: mysql

<img width="992" height="332" alt="image" src="https://github.com/user-attachments/assets/50dd7c1b-6fa0-4767-b6b5-4c64a2c85b66" />

There is a pseudo standard of a top_level.txt file available with the information that we need. This PR honours its contents